### PR TITLE
Support static property values

### DIFF
--- a/dist/cli/commands/generate.js
+++ b/dist/cli/commands/generate.js
@@ -142,28 +142,6 @@ ${eventTypes}
   groups: {
 ${groupTypes}
   };
-  globals: {
-    dimensions: {
-      [K: string]: {
-        name: string;
-        description: string;
-        identifiers: Array<{
-          property: string;
-          contains?: (string | number | boolean)[];
-          equals?: string | number | boolean;
-          not?: string | number | boolean;
-          in?: (string | number | boolean)[];
-          notIn?: (string | number | boolean)[];
-          startsWith?: string;
-          endsWith?: string;
-          lt?: number;
-          lte?: number;
-          gt?: number;
-          gte?: number;
-        }>;
-      };
-    };
-  };
 }
 
 // Base types for type safety

--- a/dist/cli/commands/generate.js
+++ b/dist/cli/commands/generate.js
@@ -47,7 +47,7 @@ function generateEventConfigs(trackingConfig, events, includeComments) {
   properties: [
     ${event.properties.map(prop => `{
       name: '${prop.name}',
-      type: ${Array.isArray(prop.type) ? JSON.stringify(prop.type) : `'${prop.type}'`}
+      type: ${Array.isArray(prop.type) ? JSON.stringify(prop.type) : `'${prop.type}'`}${prop.value !== undefined ? `,\n      value: ${JSON.stringify(prop.value)}` : ''}
     }`).join(',\n    ')}
   ]
 };`;
@@ -59,18 +59,25 @@ function generateEventConfigs(trackingConfig, events, includeComments) {
  */
 function generateTrackingConfig(globals, events) {
     const eventEntries = Object.entries(events.events || {})
-        .map(([key, _]) => `    ${key}: ${normalizeEventKey(key)}Event`)
+        .map(([key, event]) => {
+        var _a;
+        return `    ${key}: {
+      name: '${event.name}',
+      properties: [
+        ${(_a = event.properties) === null || _a === void 0 ? void 0 : _a.map((prop) => `{
+          name: '${prop.name}',
+          type: ${Array.isArray(prop.type) ? JSON.stringify(prop.type) : `'${prop.type}'`}${prop.value !== undefined ? `,\n          value: ${JSON.stringify(prop.value)}` : ''}
+        }`).join(',\n        ')}
+      ]
+    }`;
+    })
         .join(',\n');
     const groupsConfig = globals.groups.map((group) => {
-        const properties = group.properties.map((prop) => ({
-            name: prop.name,
-            type: prop.type
-        }));
-        const propertyEntries = properties.map((prop) => {
+        const propertyEntries = group.properties.map((prop) => {
             const type = Array.isArray(prop.type) ? JSON.stringify(prop.type) : `'${prop.type}'`;
             return `        {
           name: '${prop.name}',
-          type: ${type}
+          type: ${type}${prop.value !== undefined ? `,\n          value: ${JSON.stringify(prop.value)}` : ''}
         }`;
         }).join(',\n');
         return `    '${group.name}': {
@@ -97,7 +104,9 @@ function generateTypeDefinitions(events, globals) {
         var _a;
         const properties = ((_a = event.properties) === null || _a === void 0 ? void 0 : _a.map((prop) => {
             const type = Array.isArray(prop.type) ? prop.type.map((t) => `'${t}'`).join(' | ') : prop.type;
-            return `'${prop.name}': ${type} | (() => ${type})`;
+            // Make properties with default values optional
+            const isOptional = prop.optional || prop.value !== undefined;
+            return `'${prop.name}'${isOptional ? '?' : ''}: ${type} | (() => ${type})`;
         }).join('; ')) || '';
         return `    ${key}: {
       name: '${event.name}';
@@ -107,7 +116,9 @@ function generateTypeDefinitions(events, globals) {
     const groupTypes = globals.groups.map((group) => {
         const properties = group.properties.map((prop) => {
             const type = Array.isArray(prop.type) ? prop.type.map((t) => `'${t}'`).join(' | ') : prop.type;
-            return `${prop.name}: ${type} | (() => ${type})`;
+            // Make properties with default values optional
+            const isOptional = prop.optional || prop.value !== undefined;
+            return `${prop.name}${isOptional ? '?' : ''}: ${type} | (() => ${type})`;
         }).join('; ');
         return `    ${group.name}: {
       name: '${group.name}';
@@ -262,7 +273,8 @@ function registerGenerateCommand(program) {
                             properties: ((_a = event.properties) === null || _a === void 0 ? void 0 : _a.map((prop) => ({
                                 name: prop.name,
                                 type: prop.type,
-                                optional: prop.optional
+                                optional: prop.optional,
+                                value: prop.value
                             }))) || []
                         }
                     ];
@@ -276,7 +288,8 @@ function registerGenerateCommand(program) {
                             properties: ((_a = group.properties) === null || _a === void 0 ? void 0 : _a.map((prop) => ({
                                 name: prop.name,
                                 type: prop.type,
-                                optional: prop.optional
+                                optional: prop.optional,
+                                value: prop.value
                             }))) || [],
                             identifiedBy: group.identifiedBy
                         }

--- a/dist/schemas/analytics.dimensions.schema.json
+++ b/dist/schemas/analytics.dimensions.schema.json
@@ -21,8 +21,7 @@
                     "property": { "type": "string" },
                     "group": { "type": "string" },
                     "contains": {
-                      "type": "array",
-                      "items": { "type": ["string", "number", "boolean"] }
+                      "type": ["string", "number", "boolean"]
                     },
                     "equals": {
                       "type": ["string", "number", "boolean"]
@@ -70,8 +69,7 @@
                     "property": { "type": "string" },
                     "group": { "type": "string" },
                     "contains": {
-                      "type": "array",
-                      "items": { "type": ["string", "number", "boolean"] }
+                      "type": ["string", "number", "boolean"]
                     },
                     "equals": {
                       "type": ["string", "number", "boolean"]

--- a/dist/tracker.js
+++ b/dist/tracker.js
@@ -29,7 +29,19 @@ function createAnalyticsTracker(context, options) {
                 // Send the event
                 try {
                     const eventName = event.name;
-                    const resolvedEventProperties = resolveProperties(eventProperties);
+                    // Create a new object with default values
+                    const propertiesWithDefaults = {};
+                    // Add default values first
+                    if (event.properties) {
+                        for (const prop of event.properties) {
+                            if (prop.value !== undefined) {
+                                propertiesWithDefaults[prop.name] = prop.value;
+                            }
+                        }
+                    }
+                    // Override with provided properties
+                    Object.assign(propertiesWithDefaults, eventProperties);
+                    const resolvedEventProperties = resolveProperties(propertiesWithDefaults);
                     const resolvedGroupProperties = Object.fromEntries(Object.entries(groupProperties).map(([key, props]) => [
                         key,
                         resolveProperties(props)
@@ -57,7 +69,19 @@ function createAnalyticsTracker(context, options) {
                 // Send the group data
                 try {
                     const groupNameStr = group.name;
-                    const resolvedProperties = resolveProperties(properties);
+                    // Create a new object with default values
+                    const propertiesWithDefaults = {};
+                    // Add default values first
+                    if (group.properties) {
+                        for (const prop of group.properties) {
+                            if (prop.value !== undefined) {
+                                propertiesWithDefaults[prop.name] = prop.value;
+                            }
+                        }
+                    }
+                    // Override with provided properties
+                    Object.assign(propertiesWithDefaults, properties);
+                    const resolvedProperties = resolveProperties(propertiesWithDefaults);
                     onGroupUpdated(groupNameStr, resolvedProperties);
                 }
                 catch (error) {

--- a/dist/tracker.ts
+++ b/dist/tracker.ts
@@ -14,6 +14,7 @@ export interface RuntimeEvent {
     name: string;
     type: string | string[];
     optional?: boolean;
+    value?: any;
   }>;
   passthrough?: boolean;
 }
@@ -24,6 +25,7 @@ export interface RuntimeGroup {
     name: string;
     type: string | string[];
     optional?: boolean;
+    value?: any;
   }>;
   passthrough?: boolean;
 }
@@ -79,7 +81,23 @@ export function createAnalyticsTracker<T extends TrackerEvents>(
         // Send the event
         try {
           const eventName = event.name as T["events"][E]["name"];
-          const resolvedEventProperties = resolveProperties(eventProperties);
+          
+          // Create a new object with default values
+          const propertiesWithDefaults: Record<string, PropertyValue> = {};
+          
+          // Add default values first
+          if (event.properties) {
+            for (const prop of event.properties) {
+              if (prop.value !== undefined) {
+                propertiesWithDefaults[prop.name] = prop.value;
+              }
+            }
+          }
+          
+          // Override with provided properties
+          Object.assign(propertiesWithDefaults, eventProperties);
+          
+          const resolvedEventProperties = resolveProperties(propertiesWithDefaults);
           const resolvedGroupProperties = Object.fromEntries(
             Object.entries(groupProperties).map(([key, props]) => [
               key,
@@ -117,7 +135,23 @@ export function createAnalyticsTracker<T extends TrackerEvents>(
         // Send the group data
         try {
           const groupNameStr = group.name as T["groups"][G]["name"];
-          const resolvedProperties = resolveProperties(properties as Record<string, PropertyValue>);
+          
+          // Create a new object with default values
+          const propertiesWithDefaults: Record<string, PropertyValue> = {};
+          
+          // Add default values first
+          if (group.properties) {
+            for (const prop of group.properties) {
+              if (prop.value !== undefined) {
+                propertiesWithDefaults[prop.name] = prop.value;
+              }
+            }
+          }
+          
+          // Override with provided properties
+          Object.assign(propertiesWithDefaults, properties);
+          
+          const resolvedProperties = resolveProperties(propertiesWithDefaults);
           onGroupUpdated(groupNameStr, resolvedProperties);
         } catch (error) {
           onError(new Error(`Failed to update group: ${error instanceof Error ? error.message : String(error)}`));

--- a/dist/types.ts
+++ b/dist/types.ts
@@ -9,7 +9,7 @@ export interface AnalyticsSchemaProperty {
 
 export interface AnalyticsSchemaDimensionIdentifier {
   property: string;
-  contains?: (string | number | boolean)[];
+  contains?: (string | number | boolean);
   equals?: string | number | boolean;
   not?: string | number | boolean;
   in?: (string | number | boolean)[];
@@ -68,7 +68,7 @@ export interface DimensionIdentifier {
   group?: string;
   equals?: string | number | boolean;
   not?: string | number | boolean;
-  contains?: (string | number | boolean)[];
+  contains?: (string | number | boolean);
   in?: (string | number | boolean)[];
   notIn?: (string | number | boolean)[];
   startsWith?: string;

--- a/dist/types.ts
+++ b/dist/types.ts
@@ -4,6 +4,7 @@ export interface AnalyticsSchemaProperty {
   description: string;
   type: string | string[];
   optional?: boolean;
+  value?: any;
 }
 
 export interface AnalyticsSchemaDimensionIdentifier {
@@ -70,6 +71,7 @@ export interface Property {
   description: string;
   type: string | string[] | 'boolean' | 'number' | 'string' | 'string[]' | 'number[]' | 'boolean[]';
   optional?: boolean;
+  value?: any;
 }
 
 export interface Dimension {

--- a/dist/types.ts
+++ b/dist/types.ts
@@ -28,17 +28,6 @@ export interface AnalyticsSchemaDimension {
   identifiers: AnalyticsSchemaDimensionIdentifier[];
 }
 
-export interface AnalyticsSchemaGlobals {
-  dimensions: AnalyticsSchemaDimension[];
-}
-
-export interface AnalyticsSchemaEvent {
-  name: string;
-  description: string;
-  dimensions?: string[];
-  properties?: AnalyticsSchemaProperty[];
-}
-
 // Analytics Config Types
 export interface AnalyticsConfig {
   generates: GenerationConfig[];
@@ -74,49 +63,12 @@ export interface Property {
   value?: any;
 }
 
-export interface Dimension {
-  name: string;
-  description: string;
-  identifiers: {
-    AND?: Array<{
-      property: string;
-      group?: string;
-      equals?: string | number | boolean;
-      not?: string | number | boolean;
-      contains?: (string | number | boolean)[];
-      in?: (string | number | boolean)[];
-      notIn?: (string | number | boolean)[];
-      startsWith?: string;
-      endsWith?: string;
-      lt?: number;
-      lte?: number;
-      gt?: number;
-      gte?: number;
-    }>;
-    OR?: Array<{
-      property: string;
-      group?: string;
-      equals?: string | number | boolean;
-      not?: string | number | boolean;
-      contains?: (string | number | boolean)[];
-      in?: (string | number | boolean)[];
-      notIn?: (string | number | boolean)[];
-      startsWith?: string;
-      endsWith?: string;
-      lt?: number;
-      lte?: number;
-      gt?: number;
-      gte?: number;
-    }>;
-  };
-}
-
 export interface DimensionIdentifier {
   property: string;
-  group: string;
-  contains?: (string | number | boolean)[];
+  group?: string;
   equals?: string | number | boolean;
   not?: string | number | boolean;
+  contains?: (string | number | boolean)[];
   in?: (string | number | boolean)[];
   notIn?: (string | number | boolean)[];
   startsWith?: string;
@@ -125,6 +77,15 @@ export interface DimensionIdentifier {
   lte?: number;
   gt?: number;
   gte?: number;
+}
+
+export interface Dimension {
+  name: string;
+  description: string;
+  identifiers: {
+    AND?: Array<DimensionIdentifier>;
+    OR?: Array<DimensionIdentifier>;
+  };
 }
 
 // Analytics Events Types
@@ -157,28 +118,6 @@ export interface TrackerEvents {
       identifiedBy?: string;
     };
   };
-  globals: {
-    dimensions: {
-      [K: string]: {
-        name: string;
-        description: string;
-        identifiers: Array<{
-          property: string;
-          contains?: (string | number | boolean)[];
-          equals?: string | number | boolean;
-          not?: string | number | boolean;
-          in?: (string | number | boolean)[];
-          notIn?: (string | number | boolean)[];
-          startsWith?: string;
-          endsWith?: string;
-          lt?: number;
-          lte?: number;
-          gt?: number;
-          gte?: number;
-        }>;
-      };
-    };
-  };
 }
 
 export type TrackerEvent<T extends TrackerEvents> = keyof T["events"];
@@ -186,15 +125,6 @@ export type TrackerGroup<T extends TrackerEvents> = keyof T["groups"];
 
 export type EventProperties<T extends TrackerEvents, E extends TrackerEvent<T>> = T["events"][E]["properties"];
 export type GroupProperties<T extends TrackerEvents, G extends TrackerGroup<T>> = T["groups"][G]["properties"];
-
-// Helper type to make all properties optional except identifiedBy
-type RequiredProperty<T extends TrackerEvents, G extends TrackerGroup<T>> = T["groups"][G]["identifiedBy"] extends string
-  ? { [K in T["groups"][G]["identifiedBy"]]: T["groups"][G]["properties"][K] }
-  : {};
-
-type OptionalProperties<T extends TrackerEvents, G extends TrackerGroup<T>> = T["groups"][G]["identifiedBy"] extends string
-  ? Omit<T["groups"][G]["properties"], T["groups"][G]["identifiedBy"]>
-  : T["groups"][G]["properties"];
 
 export interface AnalyticsTracker<T extends TrackerEvents> {
   track: <E extends TrackerEvent<T>>(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "voltage-schema",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "voltage-schema",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
         "opener": "^1.5.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "voltage-schema",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "The analytics schema that evolves with your software.",
   "main": "./dist/cli/index.js",
   "scripts": {

--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -166,28 +166,6 @@ ${eventTypes}
   groups: {
 ${groupTypes}
   };
-  globals: {
-    dimensions: {
-      [K: string]: {
-        name: string;
-        description: string;
-        identifiers: Array<{
-          property: string;
-          contains?: (string | number | boolean)[];
-          equals?: string | number | boolean;
-          not?: string | number | boolean;
-          in?: (string | number | boolean)[];
-          notIn?: (string | number | boolean)[];
-          startsWith?: string;
-          endsWith?: string;
-          lt?: number;
-          lte?: number;
-          gt?: number;
-          gte?: number;
-        }>;
-      };
-    };
-  };
 }
 
 // Base types for type safety

--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -9,6 +9,7 @@ interface TrackingConfigProperty {
   name: string;
   type: string | string[];
   optional?: boolean;
+  value?: any;
 }
 
 interface TrackingConfig {
@@ -63,7 +64,7 @@ function generateEventConfigs(trackingConfig: TrackingConfig, events: AnalyticsE
   properties: [
     ${event.properties.map(prop => `{
       name: '${prop.name}',
-      type: ${Array.isArray(prop.type) ? JSON.stringify(prop.type) : `'${prop.type}'`}
+      type: ${Array.isArray(prop.type) ? JSON.stringify(prop.type) : `'${prop.type}'`}${prop.value !== undefined ? `,\n      value: ${JSON.stringify(prop.value)}` : ''}
     }`).join(',\n    ')}
   ]
 };`;
@@ -76,20 +77,25 @@ function generateEventConfigs(trackingConfig: TrackingConfig, events: AnalyticsE
  */
 export function generateTrackingConfig(globals: any, events: any): string {
   const eventEntries = Object.entries(events.events || {})
-    .map(([key, _]) => `    ${key}: ${normalizeEventKey(key)}Event`)
+    .map(([key, event]: [string, any]) => {
+      return `    ${key}: {
+      name: '${event.name}',
+      properties: [
+        ${event.properties?.map((prop: any) => `{
+          name: '${prop.name}',
+          type: ${Array.isArray(prop.type) ? JSON.stringify(prop.type) : `'${prop.type}'`}${prop.value !== undefined ? `,\n          value: ${JSON.stringify(prop.value)}` : ''}
+        }`).join(',\n        ')}
+      ]
+    }`;
+    })
     .join(',\n');
 
   const groupsConfig = globals.groups.map((group: any) => {
-    const properties = group.properties.map((prop: { name: string; type: string | string[] }) => ({
-      name: prop.name,
-      type: prop.type
-    }));
-
-    const propertyEntries = properties.map((prop: { name: string; type: string | string[] }) => {
+    const propertyEntries = group.properties.map((prop: any) => {
       const type = Array.isArray(prop.type) ? JSON.stringify(prop.type) : `'${prop.type}'`;
       return `        {
           name: '${prop.name}',
-          type: ${type}
+          type: ${type}${prop.value !== undefined ? `,\n          value: ${JSON.stringify(prop.value)}` : ''}
         }`;
     }).join(',\n');
 
@@ -118,7 +124,9 @@ function generateTypeDefinitions(events: AnalyticsEvents, globals: AnalyticsGlob
   const eventTypes = Object.entries(events.events).map(([key, event]) => {
     const properties = event.properties?.map((prop) => {
       const type = Array.isArray(prop.type) ? prop.type.map((t: string) => `'${t}'`).join(' | ') : prop.type;
-      return `'${prop.name}': ${type} | (() => ${type})`;
+      // Make properties with default values optional
+      const isOptional = prop.optional || prop.value !== undefined;
+      return `'${prop.name}'${isOptional ? '?' : ''}: ${type} | (() => ${type})`;
     }).join('; ') || '';
 
     return `    ${key}: {
@@ -130,7 +138,9 @@ function generateTypeDefinitions(events: AnalyticsEvents, globals: AnalyticsGlob
   const groupTypes = globals.groups.map((group) => {
     const properties = group.properties.map((prop) => {
       const type = Array.isArray(prop.type) ? prop.type.map((t: string) => `'${t}'`).join(' | ') : prop.type;
-      return `${prop.name}: ${type} | (() => ${type})`;
+      // Make properties with default values optional
+      const isOptional = prop.optional || prop.value !== undefined;
+      return `${prop.name}${isOptional ? '?' : ''}: ${type} | (() => ${type})`;
     }).join('; ');
 
     return `    ${group.name}: {
@@ -298,7 +308,8 @@ export function registerGenerateCommand(program: Command) {
                 properties: event.properties?.map((prop: AnalyticsSchemaProperty) => ({
                   name: prop.name,
                   type: prop.type,
-                  optional: prop.optional
+                  optional: prop.optional,
+                  value: prop.value
                 })) || []
               }
             ])
@@ -311,7 +322,8 @@ export function registerGenerateCommand(program: Command) {
                 properties: group.properties?.map((prop: AnalyticsSchemaProperty) => ({
                   name: prop.name,
                   type: prop.type,
-                  optional: prop.optional
+                  optional: prop.optional,
+                  value: prop.value
                 })) || [],
                 identifiedBy: group.identifiedBy
               }

--- a/src/cli/utils/analyticsDimensionUtils.ts
+++ b/src/cli/utils/analyticsDimensionUtils.ts
@@ -24,7 +24,7 @@ export interface DimensionData {
   identifiers: {
     AND?: Array<{
       property: string;
-      contains?: (string | number | boolean)[];
+      contains?: (string | number | boolean);
       equals?: string | number | boolean;
       not?: string | number | boolean;
       in?: (string | number | boolean)[];
@@ -38,7 +38,7 @@ export interface DimensionData {
     }>;
     OR?: Array<{
       property: string;
-      contains?: (string | number | boolean)[];
+      contains?: (string | number | boolean);
       equals?: string | number | boolean;
       not?: string | number | boolean;
       in?: (string | number | boolean)[];

--- a/src/cli/utils/analyticsEventUtils.ts
+++ b/src/cli/utils/analyticsEventUtils.ts
@@ -12,7 +12,7 @@ export interface EventDimension {
   identifiers: {
     AND?: Array<{
       property: string;
-      contains?: (string | number | boolean)[];
+      contains?: (string | number | boolean);
       equals?: string | number | boolean;
       not?: string | number | boolean;
       in?: (string | number | boolean)[];
@@ -26,7 +26,7 @@ export interface EventDimension {
     }>;
     OR?: Array<{
       property: string;
-      contains?: (string | number | boolean)[];
+      contains?: (string | number | boolean);
       equals?: string | number | boolean;
       not?: string | number | boolean;
       in?: (string | number | boolean)[];

--- a/src/schemas/analytics.dimensions.schema.json
+++ b/src/schemas/analytics.dimensions.schema.json
@@ -21,8 +21,7 @@
                     "property": { "type": "string" },
                     "group": { "type": "string" },
                     "contains": {
-                      "type": "array",
-                      "items": { "type": ["string", "number", "boolean"] }
+                      "type": ["string", "number", "boolean"]
                     },
                     "equals": {
                       "type": ["string", "number", "boolean"]
@@ -70,8 +69,7 @@
                     "property": { "type": "string" },
                     "group": { "type": "string" },
                     "contains": {
-                      "type": "array",
-                      "items": { "type": ["string", "number", "boolean"] }
+                      "type": ["string", "number", "boolean"]
                     },
                     "equals": {
                       "type": ["string", "number", "boolean"]

--- a/src/tracker.ts
+++ b/src/tracker.ts
@@ -14,6 +14,7 @@ export interface RuntimeEvent {
     name: string;
     type: string | string[];
     optional?: boolean;
+    value?: any;
   }>;
   passthrough?: boolean;
 }
@@ -24,6 +25,7 @@ export interface RuntimeGroup {
     name: string;
     type: string | string[];
     optional?: boolean;
+    value?: any;
   }>;
   passthrough?: boolean;
 }
@@ -79,7 +81,23 @@ export function createAnalyticsTracker<T extends TrackerEvents>(
         // Send the event
         try {
           const eventName = event.name as T["events"][E]["name"];
-          const resolvedEventProperties = resolveProperties(eventProperties);
+          
+          // Create a new object with default values
+          const propertiesWithDefaults: Record<string, PropertyValue> = {};
+          
+          // Add default values first
+          if (event.properties) {
+            for (const prop of event.properties) {
+              if (prop.value !== undefined) {
+                propertiesWithDefaults[prop.name] = prop.value;
+              }
+            }
+          }
+          
+          // Override with provided properties
+          Object.assign(propertiesWithDefaults, eventProperties);
+          
+          const resolvedEventProperties = resolveProperties(propertiesWithDefaults);
           const resolvedGroupProperties = Object.fromEntries(
             Object.entries(groupProperties).map(([key, props]) => [
               key,
@@ -117,7 +135,23 @@ export function createAnalyticsTracker<T extends TrackerEvents>(
         // Send the group data
         try {
           const groupNameStr = group.name as T["groups"][G]["name"];
-          const resolvedProperties = resolveProperties(properties as Record<string, PropertyValue>);
+          
+          // Create a new object with default values
+          const propertiesWithDefaults: Record<string, PropertyValue> = {};
+          
+          // Add default values first
+          if (group.properties) {
+            for (const prop of group.properties) {
+              if (prop.value !== undefined) {
+                propertiesWithDefaults[prop.name] = prop.value;
+              }
+            }
+          }
+          
+          // Override with provided properties
+          Object.assign(propertiesWithDefaults, properties);
+          
+          const resolvedProperties = resolveProperties(propertiesWithDefaults);
           onGroupUpdated(groupNameStr, resolvedProperties);
         } catch (error) {
           onError(new Error(`Failed to update group: ${error instanceof Error ? error.message : String(error)}`));

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,7 @@ export interface AnalyticsSchemaProperty {
 
 export interface AnalyticsSchemaDimensionIdentifier {
   property: string;
-  contains?: (string | number | boolean)[];
+  contains?: (string | number | boolean);
   equals?: string | number | boolean;
   not?: string | number | boolean;
   in?: (string | number | boolean)[];
@@ -68,7 +68,7 @@ export interface DimensionIdentifier {
   group?: string;
   equals?: string | number | boolean;
   not?: string | number | boolean;
-  contains?: (string | number | boolean)[];
+  contains?: (string | number | boolean);
   in?: (string | number | boolean)[];
   notIn?: (string | number | boolean)[];
   startsWith?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ export interface AnalyticsSchemaProperty {
   description: string;
   type: string | string[];
   optional?: boolean;
+  value?: any;
 }
 
 export interface AnalyticsSchemaDimensionIdentifier {
@@ -70,6 +71,7 @@ export interface Property {
   description: string;
   type: string | string[] | 'boolean' | 'number' | 'string' | 'string[]' | 'number[]' | 'boolean[]';
   optional?: boolean;
+  value?: any;
 }
 
 export interface Dimension {

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,17 +28,6 @@ export interface AnalyticsSchemaDimension {
   identifiers: AnalyticsSchemaDimensionIdentifier[];
 }
 
-export interface AnalyticsSchemaGlobals {
-  dimensions: AnalyticsSchemaDimension[];
-}
-
-export interface AnalyticsSchemaEvent {
-  name: string;
-  description: string;
-  dimensions?: string[];
-  properties?: AnalyticsSchemaProperty[];
-}
-
 // Analytics Config Types
 export interface AnalyticsConfig {
   generates: GenerationConfig[];
@@ -74,49 +63,12 @@ export interface Property {
   value?: any;
 }
 
-export interface Dimension {
-  name: string;
-  description: string;
-  identifiers: {
-    AND?: Array<{
-      property: string;
-      group?: string;
-      equals?: string | number | boolean;
-      not?: string | number | boolean;
-      contains?: (string | number | boolean)[];
-      in?: (string | number | boolean)[];
-      notIn?: (string | number | boolean)[];
-      startsWith?: string;
-      endsWith?: string;
-      lt?: number;
-      lte?: number;
-      gt?: number;
-      gte?: number;
-    }>;
-    OR?: Array<{
-      property: string;
-      group?: string;
-      equals?: string | number | boolean;
-      not?: string | number | boolean;
-      contains?: (string | number | boolean)[];
-      in?: (string | number | boolean)[];
-      notIn?: (string | number | boolean)[];
-      startsWith?: string;
-      endsWith?: string;
-      lt?: number;
-      lte?: number;
-      gt?: number;
-      gte?: number;
-    }>;
-  };
-}
-
 export interface DimensionIdentifier {
   property: string;
-  group: string;
-  contains?: (string | number | boolean)[];
+  group?: string;
   equals?: string | number | boolean;
   not?: string | number | boolean;
+  contains?: (string | number | boolean)[];
   in?: (string | number | boolean)[];
   notIn?: (string | number | boolean)[];
   startsWith?: string;
@@ -125,6 +77,15 @@ export interface DimensionIdentifier {
   lte?: number;
   gt?: number;
   gte?: number;
+}
+
+export interface Dimension {
+  name: string;
+  description: string;
+  identifiers: {
+    AND?: Array<DimensionIdentifier>;
+    OR?: Array<DimensionIdentifier>;
+  };
 }
 
 // Analytics Events Types
@@ -157,28 +118,6 @@ export interface TrackerEvents {
       identifiedBy?: string;
     };
   };
-  globals: {
-    dimensions: {
-      [K: string]: {
-        name: string;
-        description: string;
-        identifiers: Array<{
-          property: string;
-          contains?: (string | number | boolean)[];
-          equals?: string | number | boolean;
-          not?: string | number | boolean;
-          in?: (string | number | boolean)[];
-          notIn?: (string | number | boolean)[];
-          startsWith?: string;
-          endsWith?: string;
-          lt?: number;
-          lte?: number;
-          gt?: number;
-          gte?: number;
-        }>;
-      };
-    };
-  };
 }
 
 export type TrackerEvent<T extends TrackerEvents> = keyof T["events"];
@@ -186,15 +125,6 @@ export type TrackerGroup<T extends TrackerEvents> = keyof T["groups"];
 
 export type EventProperties<T extends TrackerEvents, E extends TrackerEvent<T>> = T["events"][E]["properties"];
 export type GroupProperties<T extends TrackerEvents, G extends TrackerGroup<T>> = T["groups"][G]["properties"];
-
-// Helper type to make all properties optional except identifiedBy
-type RequiredProperty<T extends TrackerEvents, G extends TrackerGroup<T>> = T["groups"][G]["identifiedBy"] extends string
-  ? { [K in T["groups"][G]["identifiedBy"]]: T["groups"][G]["properties"][K] }
-  : {};
-
-type OptionalProperties<T extends TrackerEvents, G extends TrackerGroup<T>> = T["groups"][G]["identifiedBy"] extends string
-  ? Omit<T["groups"][G]["properties"], T["groups"][G]["identifiedBy"]>
-  : T["groups"][G]["properties"];
 
 export interface AnalyticsTracker<T extends TrackerEvents> {
   track: <E extends TrackerEvent<T>>(


### PR DESCRIPTION
This allows users to statically define a "value" on event & group properties, so that one does not need to be provided at runtime.