### PR TITLE
Allow events & groups to not have any properties

### DIFF
--- a/dist/tracker.js
+++ b/dist/tracker.js
@@ -18,14 +18,15 @@ function createAnalyticsTracker(context, options) {
     const { onEventTracked, onGroupUpdated, onError = console.error } = options;
     const groupProperties = {};
     return {
-        track: (eventKey, eventProperties) => {
+        track: (eventKey, ...args) => {
             try {
                 const event = context.events[eventKey];
                 if (!event) {
                     throw new ValidationError(`Event "${String(eventKey)}" not found`);
                 }
+                const eventProperties = args[0];
                 // Validate properties
-                validateEventProperties(event, eventProperties);
+                validateEventProperties(event, eventProperties || {});
                 // Send the event
                 try {
                     const eventName = event.name;
@@ -40,7 +41,9 @@ function createAnalyticsTracker(context, options) {
                         }
                     }
                     // Override with provided properties
-                    Object.assign(propertiesWithDefaults, eventProperties);
+                    if (eventProperties) {
+                        Object.assign(propertiesWithDefaults, eventProperties);
+                    }
                     const resolvedEventProperties = resolveProperties(propertiesWithDefaults);
                     const resolvedGroupProperties = Object.fromEntries(Object.entries(groupProperties).map(([key, props]) => [
                         key,

--- a/dist/types.ts
+++ b/dist/types.ts
@@ -126,10 +126,13 @@ export type TrackerGroup<T extends TrackerEvents> = keyof T["groups"];
 export type EventProperties<T extends TrackerEvents, E extends TrackerEvent<T>> = T["events"][E]["properties"];
 export type GroupProperties<T extends TrackerEvents, G extends TrackerGroup<T>> = T["groups"][G]["properties"];
 
+// Helper type to determine if an event has properties
+export type HasProperties<T extends TrackerEvents, E extends TrackerEvent<T>> = EventProperties<T, E> extends Record<string, never> ? false : true;
+
 export interface AnalyticsTracker<T extends TrackerEvents> {
   track: <E extends TrackerEvent<T>>(
     eventKey: E,
-    eventProperties: EventProperties<T, E>
+    ...args: HasProperties<T, E> extends true ? [eventProperties: EventProperties<T, E>] : []
   ) => void;
   setProperties: <G extends TrackerGroup<T>>(
     groupName: G,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "voltage-schema",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "voltage-schema",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "ISC",
       "dependencies": {
         "opener": "^1.5.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "voltage-schema",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "The analytics schema that evolves with your software.",
   "main": "./dist/cli/index.js",
   "scripts": {

--- a/src/types.ts
+++ b/src/types.ts
@@ -126,10 +126,13 @@ export type TrackerGroup<T extends TrackerEvents> = keyof T["groups"];
 export type EventProperties<T extends TrackerEvents, E extends TrackerEvent<T>> = T["events"][E]["properties"];
 export type GroupProperties<T extends TrackerEvents, G extends TrackerGroup<T>> = T["groups"][G]["properties"];
 
+// Helper type to determine if an event has properties
+export type HasProperties<T extends TrackerEvents, E extends TrackerEvent<T>> = EventProperties<T, E> extends Record<string, never> ? false : true;
+
 export interface AnalyticsTracker<T extends TrackerEvents> {
   track: <E extends TrackerEvent<T>>(
     eventKey: E,
-    eventProperties: EventProperties<T, E>
+    ...args: HasProperties<T, E> extends true ? [eventProperties: EventProperties<T, E>] : []
   ) => void;
   setProperties: <G extends TrackerGroup<T>>(
     groupName: G,


### PR DESCRIPTION
Events & groups without properties should not cause typescript errors in the generated output.