### PR TITLE
V1.8.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "voltage-schema",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "voltage-schema",
-      "version": "1.8.5",
+      "version": "1.8.6",
       "license": "ISC",
       "dependencies": {
         "js-yaml": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "voltage-schema",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "description": "The analytics schema that evolves with your software.",
   "main": "./dist/cli/index.js",
   "scripts": {


### PR DESCRIPTION
Fixes a race condition when "tracker.setProperties()" & "tracker.track()" are called in succession.