### PR TITLE
Meta field updates

### DIFF
--- a/dist/cli/validation/validateAnalyticsEvents.js
+++ b/dist/cli/validation/validateAnalyticsEvents.js
@@ -63,7 +63,7 @@ function validateEventMeta(event, eventKey, metaRules) {
     else {
         // Check if any required meta fields are missing
         for (const rule of metaRules) {
-            if (!rule.optional) {
+            if (!rule.optional && !rule.defaultValue) {
                 errors.push(`Missing required meta field "${rule.name}" in event "${eventKey}"`);
             }
         }

--- a/dist/cli/validation/validateAnalyticsMeta.js
+++ b/dist/cli/validation/validateAnalyticsMeta.js
@@ -22,6 +22,51 @@ function validateMetaRuleNames(metaRules) {
     });
     return errors.length > 0 ? { isValid: false, errors } : { isValid: true };
 }
+function validateMetaRuleDefaultValues(metaRules) {
+    const errors = [];
+    metaRules.forEach((rule) => {
+        if (rule.defaultValue !== undefined) {
+            // Validate defaultValue against type
+            if (Array.isArray(rule.type)) {
+                // Type is an array of allowed values
+                if (!rule.type.includes(rule.defaultValue)) {
+                    errors.push(`Invalid defaultValue "${rule.defaultValue}" for meta rule "${rule.name}". Expected one of: ${rule.type.join(", ")}`);
+                }
+            }
+            else if (rule.type === "string") {
+                if (typeof rule.defaultValue !== "string") {
+                    errors.push(`Invalid defaultValue type for meta rule "${rule.name}". Expected string, got ${typeof rule.defaultValue}`);
+                }
+            }
+            else if (rule.type === "number") {
+                if (typeof rule.defaultValue !== "number") {
+                    errors.push(`Invalid defaultValue type for meta rule "${rule.name}". Expected number, got ${typeof rule.defaultValue}`);
+                }
+            }
+            else if (rule.type === "boolean") {
+                if (typeof rule.defaultValue !== "boolean") {
+                    errors.push(`Invalid defaultValue type for meta rule "${rule.name}". Expected boolean, got ${typeof rule.defaultValue}`);
+                }
+            }
+            else if (rule.type === "string[]") {
+                if (!Array.isArray(rule.defaultValue) || !rule.defaultValue.every(val => typeof val === "string")) {
+                    errors.push(`Invalid defaultValue type for meta rule "${rule.name}". Expected string[], got ${typeof rule.defaultValue}`);
+                }
+            }
+            else if (rule.type === "number[]") {
+                if (!Array.isArray(rule.defaultValue) || !rule.defaultValue.every(val => typeof val === "number")) {
+                    errors.push(`Invalid defaultValue type for meta rule "${rule.name}". Expected number[], got ${typeof rule.defaultValue}`);
+                }
+            }
+            else if (rule.type === "boolean[]") {
+                if (!Array.isArray(rule.defaultValue) || !rule.defaultValue.every(val => typeof val === "boolean")) {
+                    errors.push(`Invalid defaultValue type for meta rule "${rule.name}". Expected boolean[], got ${typeof rule.defaultValue}`);
+                }
+            }
+        }
+    });
+    return errors.length > 0 ? { isValid: false, errors } : { isValid: true };
+}
 function validateMeta(metaPath) {
     var _a;
     const result = (0, fileValidation_1.parseSchemaFile)(metaPath);
@@ -40,6 +85,12 @@ function validateMeta(metaPath) {
     if (!namesResult.isValid && namesResult.errors) {
         (0, logging_1.logValidationErrors)(namesResult.errors);
         return { isValid: false, errors: namesResult.errors };
+    }
+    // Check for valid defaultValues
+    const defaultValuesResult = validateMetaRuleDefaultValues(result.data.meta);
+    if (!defaultValuesResult.isValid && defaultValuesResult.errors) {
+        (0, logging_1.logValidationErrors)(defaultValuesResult.errors);
+        return { isValid: false, errors: defaultValuesResult.errors };
     }
     return result;
 }

--- a/dist/tracker.js
+++ b/dist/tracker.js
@@ -97,7 +97,7 @@ function createAnalyticsTracker(config, options) {
                 })));
                 onEventTracked(event.name, {
                     properties: resolvedProperties,
-                    meta: event.meta,
+                    meta: (event.meta || {}),
                     groups: Object.fromEntries(resolvedGroups)
                 });
             }

--- a/dist/tracker.ts
+++ b/dist/tracker.ts
@@ -17,7 +17,7 @@ export interface RuntimeEvent {
     optional?: boolean;
     defaultValue?: any;
   }>;
-  meta?: Record<string, string | number | boolean>;
+  meta: Record<string, string | number | boolean>;
   passthrough?: boolean;
 }
 
@@ -133,7 +133,7 @@ export function createAnalyticsTracker<T extends TrackerEvents>(
 
         onEventTracked(event.name as T["events"][E]["name"], {
           properties: resolvedProperties as T["events"][E]["properties"],
-          meta: event.meta as T["events"][E]["meta"],
+          meta: (event.meta || {}) as T["events"][E]["meta"],
           groups: Object.fromEntries(resolvedGroups) as { [K in TrackerGroup<T>]: T["groups"][K]["properties"] }
         });
       } catch (error) {

--- a/dist/types.ts
+++ b/dist/types.ts
@@ -123,7 +123,7 @@ export interface TrackerEvents {
     [K: string]: {
       name: string;
       properties: Record<string, any>;
-      meta?: Record<string, any>;
+      meta: Record<string, any>;
       passthrough?: boolean;
     };
   };
@@ -164,7 +164,7 @@ export interface TrackerOptions<T extends TrackerEvents> {
     eventName: T["events"][E]["name"],
     eventData: {
       properties: { [K in keyof T["events"][E]["properties"]]: T["events"][E]["properties"][K] };
-      meta?: T["events"][E]["meta"];
+      meta: T["events"][E]["meta"];
       groups: { [K in TrackerGroup<T>]: T["groups"][K]["properties"] };
     }
   ) => void | Promise<void>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "voltage-schema",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "voltage-schema",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "license": "ISC",
       "dependencies": {
         "js-yaml": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "voltage-schema",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "The analytics schema that evolves with your software.",
   "main": "./dist/cli/index.js",
   "scripts": {

--- a/src/cli/validation/validateAnalyticsEvents.ts
+++ b/src/cli/validation/validateAnalyticsEvents.ts
@@ -64,7 +64,7 @@ function validateEventMeta(event: Event, eventKey: string, metaRules: AnalyticsS
   } else {
     // Check if any required meta fields are missing
     for (const rule of metaRules) {
-      if (!rule.optional) {
+      if (!rule.optional && !rule.defaultValue) {
         errors.push(`Missing required meta field "${rule.name}" in event "${eventKey}"`);
       }
     }

--- a/src/tracker.ts
+++ b/src/tracker.ts
@@ -17,7 +17,7 @@ export interface RuntimeEvent {
     optional?: boolean;
     defaultValue?: any;
   }>;
-  meta?: Record<string, string | number | boolean>;
+  meta: Record<string, string | number | boolean>;
   passthrough?: boolean;
 }
 
@@ -133,7 +133,7 @@ export function createAnalyticsTracker<T extends TrackerEvents>(
 
         onEventTracked(event.name as T["events"][E]["name"], {
           properties: resolvedProperties as T["events"][E]["properties"],
-          meta: event.meta as T["events"][E]["meta"],
+          meta: (event.meta || {}) as T["events"][E]["meta"],
           groups: Object.fromEntries(resolvedGroups) as { [K in TrackerGroup<T>]: T["groups"][K]["properties"] }
         });
       } catch (error) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -123,7 +123,7 @@ export interface TrackerEvents {
     [K: string]: {
       name: string;
       properties: Record<string, any>;
-      meta?: Record<string, any>;
+      meta: Record<string, any>;
       passthrough?: boolean;
     };
   };
@@ -164,7 +164,7 @@ export interface TrackerOptions<T extends TrackerEvents> {
     eventName: T["events"][E]["name"],
     eventData: {
       properties: { [K in keyof T["events"][E]["properties"]]: T["events"][E]["properties"][K] };
-      meta?: T["events"][E]["meta"];
+      meta: T["events"][E]["meta"];
       groups: { [K in TrackerGroup<T>]: T["groups"][K]["properties"] };
     }
   ) => void | Promise<void>;


### PR DESCRIPTION
- Meta rules are considered optional when they provide a defaultValue
- Meta rule defaultValues must match the meta rule type
- Generated types for events now include full typesafety & typeahead for their meta fields