### PR TITLE
Generate a deterministic voltage.lock file in the package root

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,9 @@ npm voltage validate
 # Generate TypeScript types & tracking config from your codegen config
 npm voltage generate
 
+# Concatenate voltage.lock files in a monorepo (run from monorepo root)
+npm voltage concat-lock
+
 # List all events and their properties
 npm voltage events
 npm voltage events -- --include-groups
@@ -309,6 +312,33 @@ npm voltage dimensions
 npm voltage dimensions -- --include-event-details
 npm voltage dimensions -- --verbose
 ```
+
+### Lock Files
+
+Voltage automatically generates a `voltage.lock` file when you run `npm voltage generate`. This file contains:
+
+- **Deterministic Versioning**: Uses semantic versioning (major.minor) that only increments when schema changes are detected
+- **Content Hashing**: Ensures reproducible builds by tracking exact schema file contents
+- **Source Tracking**: Records all schema files, their data, and their relationships
+- **Generation Metadata**: Stores configuration and output paths for each generation target
+
+The lock file ensures that your generated types and tracking configurations remain consistent across environments and team members.
+
+#### Monorepo Support
+
+For monorepos with multiple packages containing voltage.lock files, use the `concat-lock` command:
+
+```bash
+# Run from your monorepo root
+npm voltage concat-lock
+```
+
+This command:
+- Scans all packages for voltage.lock files
+- Validates each package has a corresponding package.json
+- Concatenates all lock files into a single monorepo voltage.lock
+- Uses deterministic versioning that only changes when underlying package lock files change
+- Outputs to the monorepo root for easy integration with CI/CD and external tools
 
 ### Auto-doc Package
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4466,10 +4466,10 @@
       }
     },
     "packages/voltage-autodoc": {
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "ISC",
       "dependencies": {
-        "voltage-schema": "^1.9.2"
+        "voltage-schema": "^2.0.0"
       },
       "bin": {
         "voltage-autodoc": "dist/index.js"
@@ -4496,24 +4496,8 @@
         "node": ">=4.2.0"
       }
     },
-    "packages/voltage-autodoc/node_modules/voltage-schema": {
-      "version": "1.9.6",
-      "resolved": "https://registry.npmjs.org/voltage-schema/-/voltage-schema-1.9.6.tgz",
-      "integrity": "sha512-CH8JHioRyHJjPybdnGOrnr9v1R4E7hlkwAk6mjCdIVNBdoNc+KhdLnK2FDBb4Q9kS4k9pt6r5oIHX2d3VmnAVw==",
-      "license": "ISC",
-      "dependencies": {
-        "ajv": "^8.17.1",
-        "js-yaml": "^4.1.0"
-      },
-      "bin": {
-        "voltage": "dist/cli/index.js"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "packages/voltage-schema": {
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "ISC",
       "dependencies": {
         "ajv": "^8.17.1",

--- a/packages/voltage-autodoc/package.json
+++ b/packages/voltage-autodoc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "voltage-autodoc",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Auto-documentation generator for Voltage analytics schemas",
   "main": "./dist/index.js",
   "scripts": {
@@ -15,7 +15,7 @@
   "author": "Matthew Rheault",
   "license": "ISC",
   "dependencies": {
-    "voltage-schema": "^1.9.2"
+    "voltage-schema": "^2.0.0"
   },
   "devDependencies": {
     "@types/node": "^16.18.0",

--- a/packages/voltage-schema/README.md
+++ b/packages/voltage-schema/README.md
@@ -294,6 +294,9 @@ npm voltage validate
 # Generate TypeScript types & tracking config from your codegen config
 npm voltage generate
 
+# Concatenate voltage.lock files in a monorepo (run from monorepo root)
+npm voltage concat-lock
+
 # List all events and their properties
 npm voltage events
 npm voltage events -- --include-groups
@@ -309,6 +312,33 @@ npm voltage dimensions
 npm voltage dimensions -- --include-event-details
 npm voltage dimensions -- --verbose
 ```
+
+## Lock Files
+
+Voltage automatically generates a `voltage.lock` file when you run `npm voltage generate`. This file contains:
+
+- **Deterministic Versioning**: Uses semantic versioning (major.minor) that only increments when schema changes are detected
+- **Content Hashing**: Ensures reproducible builds by tracking exact schema file contents
+- **Source Tracking**: Records all schema files, their data, and their relationships
+- **Generation Metadata**: Stores configuration and output paths for each generation target
+
+The lock file ensures that your generated types and tracking configurations remain consistent across environments and team members.
+
+### Monorepo Support
+
+For monorepos with multiple packages containing voltage.lock files, use the `concat-lock` command:
+
+```bash
+# Run from your monorepo root
+npm voltage concat-lock
+```
+
+This command:
+- Scans all packages for voltage.lock files
+- Validates each package has a corresponding package.json
+- Concatenates all lock files into a single monorepo voltage.lock
+- Uses deterministic versioning that only changes when underlying package lock files change
+- Outputs to the monorepo root for easy integration with CI/CD and external tools
 
 ## License
 

--- a/packages/voltage-schema/dist/cli/commands/concat-lock.js
+++ b/packages/voltage-schema/dist/cli/commands/concat-lock.js
@@ -1,0 +1,231 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.registerConcatLockCommand = exports.concatLockCommand = exports.writeMonorepoLockFile = exports.createMonorepoLockFile = exports.readExistingMonorepoLockFile = exports.getPackageInfo = exports.findVoltageLockFiles = exports.validateMonorepoRoot = void 0;
+const fs_1 = __importDefault(require("fs"));
+const path_1 = __importDefault(require("path"));
+const lockFileGenerator_1 = require("../utils/lockFileGenerator");
+/**
+ * Validates that the command is being run from a monorepo root
+ */
+function validateMonorepoRoot(rootDir) {
+    const packageJsonPath = path_1.default.join(rootDir, 'package.json');
+    if (!fs_1.default.existsSync(packageJsonPath)) {
+        throw new Error('No package.json found in current directory. The concat-lock command must be run from the monorepo root.');
+    }
+    try {
+        const packageJson = JSON.parse(fs_1.default.readFileSync(packageJsonPath, 'utf8'));
+        // Optional: Check for workspaces field to confirm it's a monorepo
+        // This is just for informational purposes, not required
+        if (packageJson.workspaces) {
+            console.log('📦 Detected monorepo with workspaces configuration');
+        }
+    }
+    catch (error) {
+        throw new Error('Invalid package.json in current directory');
+    }
+}
+exports.validateMonorepoRoot = validateMonorepoRoot;
+/**
+ * Scans a directory recursively for voltage.lock files
+ * Ensures each voltage.lock has an associated package.json
+ */
+function findVoltageLockFiles(rootDir) {
+    const lockFiles = [];
+    function scanDirectory(dir) {
+        try {
+            const entries = fs_1.default.readdirSync(dir, { withFileTypes: true });
+            for (const entry of entries) {
+                const fullPath = path_1.default.join(dir, entry.name);
+                if (entry.isDirectory()) {
+                    // Skip node_modules and hidden directories
+                    if (entry.name !== 'node_modules' && !entry.name.startsWith('.')) {
+                        scanDirectory(fullPath);
+                    }
+                }
+                else if (entry.isFile() && entry.name === 'voltage.lock') {
+                    // Skip the root monorepo voltage.lock file
+                    if (dir === rootDir) {
+                        continue;
+                    }
+                    // Check if package.json exists alongside voltage.lock
+                    const packageJsonPath = path_1.default.join(dir, 'package.json');
+                    if (!fs_1.default.existsSync(packageJsonPath)) {
+                        throw new Error(`Found voltage.lock at ${fullPath} but no package.json in the same directory. Each voltage.lock must be in a package root with a package.json.`);
+                    }
+                    lockFiles.push(fullPath);
+                }
+            }
+        }
+        catch (error) {
+            if (error instanceof Error && error.message.includes('voltage.lock')) {
+                throw error; // Re-throw voltage.lock validation errors
+            }
+            // Skip directories we can't read
+        }
+    }
+    scanDirectory(rootDir);
+    return lockFiles;
+}
+exports.findVoltageLockFiles = findVoltageLockFiles;
+/**
+ * Reads package.json for a given voltage.lock file to get package info
+ * This function assumes package.json exists (validated by findVoltageLockFiles)
+ */
+function getPackageInfo(lockFilePath) {
+    const packageDir = path_1.default.dirname(lockFilePath);
+    const packageJsonPath = path_1.default.join(packageDir, 'package.json');
+    try {
+        const packageJson = JSON.parse(fs_1.default.readFileSync(packageJsonPath, 'utf8'));
+        return {
+            name: packageJson.name || path_1.default.basename(packageDir),
+            version: packageJson.version || '0.0.0'
+        };
+    }
+    catch (error) {
+        throw new Error(`Could not read package.json at ${packageJsonPath}: ${error}`);
+    }
+}
+exports.getPackageInfo = getPackageInfo;
+/**
+ * Reads existing monorepo lock file if it exists
+ */
+function readExistingMonorepoLockFile(outputPath) {
+    if (!fs_1.default.existsSync(outputPath)) {
+        return null;
+    }
+    try {
+        const content = fs_1.default.readFileSync(outputPath, 'utf8');
+        const lockFile = JSON.parse(content);
+        // Validate it's a monorepo lock file
+        if (lockFile.isMonoRepo === true && Array.isArray(lockFile.packages)) {
+            return lockFile;
+        }
+        return null;
+    }
+    catch (error) {
+        // If we can't parse the existing file, treat it as if it doesn't exist
+        return null;
+    }
+}
+exports.readExistingMonorepoLockFile = readExistingMonorepoLockFile;
+/**
+ * Creates a concatenated monorepo lock file from individual package lock files
+ */
+function createMonorepoLockFile(rootDir, existingMonorepoLock) {
+    const lockFilePaths = findVoltageLockFiles(rootDir);
+    if (lockFilePaths.length === 0) {
+        throw new Error('No voltage.lock files found in the monorepo');
+    }
+    const packages = [];
+    let highestSchemaVersion = '0.0.0';
+    for (const lockFilePath of lockFilePaths) {
+        try {
+            // Read the lock file
+            const lockFileContent = fs_1.default.readFileSync(lockFilePath, 'utf8');
+            const lockData = JSON.parse(lockFileContent);
+            // Get package info
+            const packageInfo = getPackageInfo(lockFilePath);
+            // Calculate relative path from root
+            const relativePath = path_1.default.relative(rootDir, lockFilePath);
+            // Track highest schema version
+            if (lockData.voltageSchemaVersion > highestSchemaVersion) {
+                highestSchemaVersion = lockData.voltageSchemaVersion;
+            }
+            packages.push({
+                packageName: packageInfo.name,
+                packageVersion: packageInfo.version,
+                file: relativePath,
+                data: lockData
+            });
+        }
+        catch (error) {
+            throw new Error(`Could not process voltage.lock file at ${lockFilePath}: ${error}`);
+        }
+    }
+    if (packages.length === 0) {
+        throw new Error('No valid voltage.lock files could be processed');
+    }
+    // Sort packages by name for deterministic output
+    packages.sort((a, b) => a.packageName.localeCompare(b.packageName));
+    // Create the monorepo lock file (without version and hash initially)
+    const monorepoLockContent = {
+        voltageSchemaVersion: highestSchemaVersion,
+        isMonoRepo: true,
+        packages
+    };
+    // Generate hash for the content
+    const contentHash = (0, lockFileGenerator_1.createContentHash)(monorepoLockContent);
+    // Determine version based on existing monorepo lock file
+    let version = '1.0';
+    if (existingMonorepoLock) {
+        if (existingMonorepoLock.hash === contentHash) {
+            // No changes, keep existing version
+            const { major, minor } = (0, lockFileGenerator_1.parseVersion)(existingMonorepoLock.version);
+            version = (0, lockFileGenerator_1.createVersion)(major, minor);
+        }
+        else {
+            // Changes detected, increment minor version
+            const { major, minor } = (0, lockFileGenerator_1.parseVersion)(existingMonorepoLock.version);
+            version = (0, lockFileGenerator_1.createVersion)(major, minor + 1);
+        }
+    }
+    return Object.assign(Object.assign({}, monorepoLockContent), { version, hash: contentHash });
+}
+exports.createMonorepoLockFile = createMonorepoLockFile;
+/**
+ * Writes the monorepo lock file to disk
+ */
+function writeMonorepoLockFile(monorepoLock, outputPath) {
+    const content = JSON.stringify(monorepoLock, null, 0); // Minified JSON
+    fs_1.default.writeFileSync(outputPath, content, 'utf8');
+}
+exports.writeMonorepoLockFile = writeMonorepoLockFile;
+/**
+ * Main concat-lock command implementation
+ */
+function concatLockCommand() {
+    const rootDir = process.cwd();
+    const outputPath = path_1.default.join(rootDir, 'voltage.lock'); // Always output to monorepo root
+    console.log('🔍 Validating monorepo root...');
+    try {
+        // Validate we're in a monorepo root
+        validateMonorepoRoot(rootDir);
+        console.log('🔍 Scanning for voltage.lock files in monorepo...');
+        // Read existing monorepo lock file for deterministic versioning
+        const existingMonorepoLock = readExistingMonorepoLockFile(outputPath);
+        // Create new monorepo lock file
+        const monorepoLock = createMonorepoLockFile(rootDir, existingMonorepoLock);
+        // Check if anything actually changed
+        if (existingMonorepoLock && existingMonorepoLock.hash === monorepoLock.hash) {
+            console.log('✅ No changes detected in package voltage.lock files');
+            console.log(`📄 Monorepo voltage.lock is up to date (version ${monorepoLock.version})`);
+            return;
+        }
+        console.log(`✅ Found ${monorepoLock.packages.length} package(s) with voltage.lock files:`);
+        for (const pkg of monorepoLock.packages) {
+            console.log(`   - ${pkg.packageName}@${pkg.packageVersion} (${pkg.file})`);
+        }
+        writeMonorepoLockFile(monorepoLock, outputPath);
+        const action = existingMonorepoLock ? 'Updated' : 'Generated';
+        console.log(`✅ ${action} monorepo voltage.lock (version ${monorepoLock.version})`);
+    }
+    catch (error) {
+        console.error(`❌ Error: ${error instanceof Error ? error.message : 'Unknown error'}`);
+        process.exit(1);
+    }
+}
+exports.concatLockCommand = concatLockCommand;
+/**
+ * Register the concat-lock command with the CLI
+ */
+function registerConcatLockCommand(cli) {
+    cli
+        .command('concat-lock', 'Concatenate multiple voltage.lock files from packages in a monorepo')
+        .action(() => {
+        concatLockCommand();
+    });
+}
+exports.registerConcatLockCommand = registerConcatLockCommand;

--- a/packages/voltage-schema/dist/cli/commands/generate.js
+++ b/packages/voltage-schema/dist/cli/commands/generate.js
@@ -9,6 +9,7 @@ const path_1 = __importDefault(require("path"));
 const validation_1 = require("../validation");
 const analyticsConfigHelper_1 = require("../utils/analyticsConfigHelper");
 const fileValidation_1 = require("../validation/fileValidation");
+const lockFileGenerator_1 = require("../utils/lockFileGenerator");
 /**
  * Normalizes an event key to be safe for use as a variable name.
  * Converts to CamelCase and removes unsafe characters.
@@ -308,6 +309,11 @@ function registerGenerateCommand(cli) {
             }
             const config = (0, analyticsConfigHelper_1.getAnalyticsConfig)();
             const generationConfigs = config.generates;
+            // Generate voltage.lock file first - this validates all schema files
+            console.log("🔐 Generating voltage.lock file...");
+            const lockFile = (0, lockFileGenerator_1.generateLockFile)(generationConfigs);
+            (0, lockFileGenerator_1.writeLockFile)(lockFile);
+            console.log("✅ Generated voltage.lock");
             generationConfigs.forEach((generationConfig) => {
                 const { events, groups, dimensions, meta, output, disableComments, eventKeyPropertyName } = generationConfig;
                 // Parse events file

--- a/packages/voltage-schema/dist/cli/index.js
+++ b/packages/voltage-schema/dist/cli/index.js
@@ -7,6 +7,7 @@ const dimensions_1 = require("./commands/dimensions");
 const properties_1 = require("./commands/properties");
 const events_1 = require("./commands/events");
 const generate_1 = require("./commands/generate");
+const concat_lock_1 = require("./commands/concat-lock");
 const cli = new cli_1.CLI();
 // Register all commands
 (0, init_1.registerInitCommand)(cli);
@@ -15,5 +16,6 @@ const cli = new cli_1.CLI();
 (0, properties_1.registerPropertiesCommand)(cli);
 (0, events_1.registerEventsCommand)(cli);
 (0, generate_1.registerGenerateCommand)(cli);
+(0, concat_lock_1.registerConcatLockCommand)(cli);
 // Parse command line arguments
 cli.parse(process.argv);

--- a/packages/voltage-schema/dist/cli/utils/lockFileGenerator.js
+++ b/packages/voltage-schema/dist/cli/utils/lockFileGenerator.js
@@ -1,0 +1,217 @@
+"use strict";
+var __rest = (this && this.__rest) || function (s, e) {
+    var t = {};
+    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
+        t[p] = s[p];
+    if (s != null && typeof Object.getOwnPropertySymbols === "function")
+        for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++) {
+            if (e.indexOf(p[i]) < 0 && Object.prototype.propertyIsEnumerable.call(s, p[i]))
+                t[p[i]] = s[p[i]];
+        }
+    return t;
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.writeLockFile = exports.generateLockFile = exports.processGenerationConfig = exports.readExistingLockFile = exports.getVoltageSchemaVersion = exports.readSchemaSource = exports.createContentHash = exports.createVersion = exports.parseVersion = void 0;
+const fs_1 = __importDefault(require("fs"));
+const path_1 = __importDefault(require("path"));
+const crypto_1 = __importDefault(require("crypto"));
+const fileValidation_1 = require("../validation/fileValidation");
+/**
+ * Parses a version (string or number) into major and minor components
+ * Handles migration from old integer versions to new semver format
+ */
+function parseVersion(version) {
+    if (typeof version === 'number') {
+        // Legacy integer version - convert to major.0
+        return {
+            major: version,
+            minor: 0
+        };
+    }
+    const parts = version.split('.');
+    return {
+        major: parseInt(parts[0] || '1', 10),
+        minor: parseInt(parts[1] || '0', 10)
+    };
+}
+exports.parseVersion = parseVersion;
+/**
+ * Creates a version string from major and minor numbers
+ */
+function createVersion(major, minor) {
+    return `${major}.${minor}`;
+}
+exports.createVersion = createVersion;
+// Note: Breaking change detection can be added later if needed
+// For now, we'll keep it simple and treat all changes as minor version bumps
+/**
+ * Creates a deterministic hash for any object
+ */
+function createContentHash(content) {
+    // Create a deep deterministic JSON string with sorted keys at all levels
+    const normalizedContent = JSON.stringify(content, (key, value) => {
+        if (value && typeof value === 'object' && !Array.isArray(value)) {
+            // Sort object keys for deterministic output
+            const sorted = {};
+            Object.keys(value).sort().forEach(k => {
+                sorted[k] = value[k];
+            });
+            return sorted;
+        }
+        return value;
+    });
+    return crypto_1.default.createHash('sha256').update(normalizedContent).digest('hex').substring(0, 16);
+}
+exports.createContentHash = createContentHash;
+/**
+ * Reads and processes a schema file, returning source data with hash
+ */
+function readSchemaSource(filePath) {
+    const absolutePath = path_1.default.resolve(process.cwd(), filePath);
+    if (!fs_1.default.existsSync(absolutePath)) {
+        throw new Error(`Schema file not found: ${filePath}`);
+    }
+    const result = (0, fileValidation_1.parseSchemaFile)(absolutePath);
+    if (!result.isValid || !result.data) {
+        const errorMessage = result.errors ? result.errors.join(', ') : 'Unknown parsing error';
+        throw new Error(`Failed to parse schema file ${filePath}: ${errorMessage}`);
+    }
+    return {
+        file: filePath,
+        data: result.data,
+        hash: createContentHash(result.data)
+    };
+}
+exports.readSchemaSource = readSchemaSource;
+/**
+ * Gets the voltage-schema package version
+ */
+function getVoltageSchemaVersion() {
+    try {
+        const packageJsonPath = path_1.default.resolve(__dirname, '../../../package.json');
+        const packageJson = JSON.parse(fs_1.default.readFileSync(packageJsonPath, 'utf8'));
+        return packageJson.version;
+    }
+    catch (error) {
+        // Fallback if we can't read the package.json
+        return '0.0.0';
+    }
+}
+exports.getVoltageSchemaVersion = getVoltageSchemaVersion;
+/**
+ * Reads the existing lock file if it exists
+ */
+function readExistingLockFile() {
+    const lockFilePath = path_1.default.resolve(process.cwd(), 'voltage.lock');
+    if (!fs_1.default.existsSync(lockFilePath)) {
+        return null;
+    }
+    try {
+        const content = fs_1.default.readFileSync(lockFilePath, 'utf8');
+        return JSON.parse(content);
+    }
+    catch (error) {
+        // If we can't parse the existing lock file, treat it as if it doesn't exist
+        return null;
+    }
+}
+exports.readExistingLockFile = readExistingLockFile;
+/**
+ * Processes a generation config and returns the generation entry
+ */
+function processGenerationConfig(genConfig, existingEntry) {
+    const sources = {
+        events: readSchemaSource(genConfig.events)
+    };
+    // Process groups if present
+    if (genConfig.groups && genConfig.groups.length > 0) {
+        sources.groups = genConfig.groups.map(groupFile => readSchemaSource(groupFile));
+    }
+    // Process dimensions if present
+    if (genConfig.dimensions && genConfig.dimensions.length > 0) {
+        sources.dimensions = genConfig.dimensions.map(dimensionFile => readSchemaSource(dimensionFile));
+    }
+    // Process meta if present
+    if (genConfig.meta) {
+        sources.meta = readSchemaSource(genConfig.meta);
+    }
+    // Create config without output for hashing
+    const { output } = genConfig, configWithoutOutput = __rest(genConfig, ["output"]);
+    // Create hash for this generation entry
+    const entryContent = {
+        config: configWithoutOutput,
+        sources
+    };
+    const entryHash = createContentHash(entryContent);
+    // Determine version using semantic versioning
+    let version = '1.0';
+    if (existingEntry) {
+        if (existingEntry.hash === entryHash) {
+            // No changes, keep existing version (convert to string format if needed)
+            const { major, minor } = parseVersion(existingEntry.version);
+            version = createVersion(major, minor);
+        }
+        else {
+            // Changes detected, increment minor version
+            const { major, minor } = parseVersion(existingEntry.version);
+            version = createVersion(major, minor + 1);
+        }
+    }
+    return {
+        output: genConfig.output,
+        config: configWithoutOutput,
+        sources,
+        hash: entryHash,
+        version
+    };
+}
+exports.processGenerationConfig = processGenerationConfig;
+/**
+ * Generates the complete voltage.lock file
+ */
+function generateLockFile(generationConfigs) {
+    const existingLockFile = readExistingLockFile();
+    const voltageSchemaVersion = getVoltageSchemaVersion();
+    // Process each generation config
+    const generates = generationConfigs.map(genConfig => {
+        // Find existing entry by output path for version comparison
+        const existingEntry = existingLockFile === null || existingLockFile === void 0 ? void 0 : existingLockFile.generates.find(entry => entry.output === genConfig.output);
+        return processGenerationConfig(genConfig, existingEntry);
+    });
+    // Create overall lock file content
+    const lockFileContent = {
+        voltageSchemaVersion,
+        configFile: 'voltage.config.js',
+        generates
+    };
+    // Create hash for overall lock file
+    const lockFileHash = createContentHash(lockFileContent);
+    // Determine overall version based on highest generation entry version change
+    let version = '1.0';
+    if (existingLockFile) {
+        if (existingLockFile.hash === lockFileHash) {
+            // No changes, keep existing version (convert to string format if needed)
+            const { major, minor } = parseVersion(existingLockFile.version);
+            version = createVersion(major, minor);
+        }
+        else {
+            // Changes detected, increment minor version
+            const { major: currentMajor, minor: currentMinor } = parseVersion(existingLockFile.version);
+            version = createVersion(currentMajor, currentMinor + 1);
+        }
+    }
+    return Object.assign(Object.assign({}, lockFileContent), { version, hash: lockFileHash });
+}
+exports.generateLockFile = generateLockFile;
+/**
+ * Writes the lock file to disk (minified)
+ */
+function writeLockFile(lockFile) {
+    const lockFilePath = path_1.default.resolve(process.cwd(), 'voltage.lock');
+    const content = JSON.stringify(lockFile, null, 0); // Minified JSON
+    fs_1.default.writeFileSync(lockFilePath, content, 'utf8');
+}
+exports.writeLockFile = writeLockFile;

--- a/packages/voltage-schema/package.json
+++ b/packages/voltage-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "voltage-schema",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Self-documenting & type-safe product analytics tracking.",
   "main": "./dist/cli/index.js",
   "scripts": {

--- a/packages/voltage-schema/src/cli/commands/concat-lock.ts
+++ b/packages/voltage-schema/src/cli/commands/concat-lock.ts
@@ -1,0 +1,272 @@
+import fs from 'fs';
+import path from 'path';
+import { VoltageLockFile, createContentHash, createVersion, parseVersion } from '../utils/lockFileGenerator';
+import { CLI } from '../cli';
+
+export interface MonorepoPackage {
+  packageName: string;
+  packageVersion: string;
+  file: string; // relative path to voltage.lock
+  data: VoltageLockFile;
+}
+
+export interface MonorepoLockFile {
+  hash: string;
+  voltageSchemaVersion: string;
+  version: string;
+  isMonoRepo: true;
+  packages: MonorepoPackage[];
+}
+
+/**
+ * Validates that the command is being run from a monorepo root
+ */
+export function validateMonorepoRoot(rootDir: string): void {
+  const packageJsonPath = path.join(rootDir, 'package.json');
+
+  if (!fs.existsSync(packageJsonPath)) {
+    throw new Error('No package.json found in current directory. The concat-lock command must be run from the monorepo root.');
+  }
+
+  try {
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+    // Optional: Check for workspaces field to confirm it's a monorepo
+    // This is just for informational purposes, not required
+    if (packageJson.workspaces) {
+      console.log('📦 Detected monorepo with workspaces configuration');
+    }
+  } catch (error) {
+    throw new Error('Invalid package.json in current directory');
+  }
+}
+
+/**
+ * Scans a directory recursively for voltage.lock files
+ * Ensures each voltage.lock has an associated package.json
+ */
+export function findVoltageLockFiles(rootDir: string): string[] {
+  const lockFiles: string[] = [];
+
+  function scanDirectory(dir: string) {
+    try {
+      const entries = fs.readdirSync(dir, { withFileTypes: true });
+
+      for (const entry of entries) {
+        const fullPath = path.join(dir, entry.name);
+
+        if (entry.isDirectory()) {
+          // Skip node_modules and hidden directories
+          if (entry.name !== 'node_modules' && !entry.name.startsWith('.')) {
+            scanDirectory(fullPath);
+          }
+        } else if (entry.isFile() && entry.name === 'voltage.lock') {
+          // Skip the root monorepo voltage.lock file
+          if (dir === rootDir) {
+            continue;
+          }
+
+          // Check if package.json exists alongside voltage.lock
+          const packageJsonPath = path.join(dir, 'package.json');
+          if (!fs.existsSync(packageJsonPath)) {
+            throw new Error(`Found voltage.lock at ${fullPath} but no package.json in the same directory. Each voltage.lock must be in a package root with a package.json.`);
+          }
+          lockFiles.push(fullPath);
+        }
+      }
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('voltage.lock')) {
+        throw error; // Re-throw voltage.lock validation errors
+      }
+      // Skip directories we can't read
+    }
+  }
+
+  scanDirectory(rootDir);
+  return lockFiles;
+}
+
+/**
+ * Reads package.json for a given voltage.lock file to get package info
+ * This function assumes package.json exists (validated by findVoltageLockFiles)
+ */
+export function getPackageInfo(lockFilePath: string): { name: string; version: string } {
+  const packageDir = path.dirname(lockFilePath);
+  const packageJsonPath = path.join(packageDir, 'package.json');
+
+  try {
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+    return {
+      name: packageJson.name || path.basename(packageDir),
+      version: packageJson.version || '0.0.0'
+    };
+  } catch (error) {
+    throw new Error(`Could not read package.json at ${packageJsonPath}: ${error}`);
+  }
+}
+
+/**
+ * Reads existing monorepo lock file if it exists
+ */
+export function readExistingMonorepoLockFile(outputPath: string): MonorepoLockFile | null {
+  if (!fs.existsSync(outputPath)) {
+    return null;
+  }
+
+  try {
+    const content = fs.readFileSync(outputPath, 'utf8');
+    const lockFile = JSON.parse(content);
+
+    // Validate it's a monorepo lock file
+    if (lockFile.isMonoRepo === true && Array.isArray(lockFile.packages)) {
+      return lockFile as MonorepoLockFile;
+    }
+
+    return null;
+  } catch (error) {
+    // If we can't parse the existing file, treat it as if it doesn't exist
+    return null;
+  }
+}
+
+/**
+ * Creates a concatenated monorepo lock file from individual package lock files
+ */
+export function createMonorepoLockFile(rootDir: string, existingMonorepoLock?: MonorepoLockFile | null): MonorepoLockFile {
+  const lockFilePaths = findVoltageLockFiles(rootDir);
+
+  if (lockFilePaths.length === 0) {
+    throw new Error('No voltage.lock files found in the monorepo');
+  }
+
+  const packages: MonorepoPackage[] = [];
+  let highestSchemaVersion = '0.0.0';
+
+  for (const lockFilePath of lockFilePaths) {
+    try {
+      // Read the lock file
+      const lockFileContent = fs.readFileSync(lockFilePath, 'utf8');
+      const lockData: VoltageLockFile = JSON.parse(lockFileContent);
+
+      // Get package info
+      const packageInfo = getPackageInfo(lockFilePath);
+
+      // Calculate relative path from root
+      const relativePath = path.relative(rootDir, lockFilePath);
+
+      // Track highest schema version
+      if (lockData.voltageSchemaVersion > highestSchemaVersion) {
+        highestSchemaVersion = lockData.voltageSchemaVersion;
+      }
+
+      packages.push({
+        packageName: packageInfo.name,
+        packageVersion: packageInfo.version,
+        file: relativePath,
+        data: lockData
+      });
+
+    } catch (error) {
+      throw new Error(`Could not process voltage.lock file at ${lockFilePath}: ${error}`);
+    }
+  }
+
+  if (packages.length === 0) {
+    throw new Error('No valid voltage.lock files could be processed');
+  }
+
+  // Sort packages by name for deterministic output
+  packages.sort((a, b) => a.packageName.localeCompare(b.packageName));
+
+  // Create the monorepo lock file (without version and hash initially)
+  const monorepoLockContent = {
+    voltageSchemaVersion: highestSchemaVersion,
+    isMonoRepo: true as const,
+    packages
+  };
+
+  // Generate hash for the content
+  const contentHash = createContentHash(monorepoLockContent);
+
+  // Determine version based on existing monorepo lock file
+  let version = '1.0';
+  if (existingMonorepoLock) {
+    if (existingMonorepoLock.hash === contentHash) {
+      // No changes, keep existing version
+      const { major, minor } = parseVersion(existingMonorepoLock.version);
+      version = createVersion(major, minor);
+    } else {
+      // Changes detected, increment minor version
+      const { major, minor } = parseVersion(existingMonorepoLock.version);
+      version = createVersion(major, minor + 1);
+    }
+  }
+
+  return {
+    ...monorepoLockContent,
+    version,
+    hash: contentHash
+  };
+}
+
+/**
+ * Writes the monorepo lock file to disk
+ */
+export function writeMonorepoLockFile(monorepoLock: MonorepoLockFile, outputPath: string): void {
+  const content = JSON.stringify(monorepoLock, null, 0); // Minified JSON
+  fs.writeFileSync(outputPath, content, 'utf8');
+}
+
+/**
+ * Main concat-lock command implementation
+ */
+export function concatLockCommand(): void {
+  const rootDir = process.cwd();
+  const outputPath = path.join(rootDir, 'voltage.lock'); // Always output to monorepo root
+
+  console.log('🔍 Validating monorepo root...');
+
+  try {
+    // Validate we're in a monorepo root
+    validateMonorepoRoot(rootDir);
+
+    console.log('🔍 Scanning for voltage.lock files in monorepo...');
+
+    // Read existing monorepo lock file for deterministic versioning
+    const existingMonorepoLock = readExistingMonorepoLockFile(outputPath);
+
+    // Create new monorepo lock file
+    const monorepoLock = createMonorepoLockFile(rootDir, existingMonorepoLock);
+
+    // Check if anything actually changed
+    if (existingMonorepoLock && existingMonorepoLock.hash === monorepoLock.hash) {
+      console.log('✅ No changes detected in package voltage.lock files');
+      console.log(`📄 Monorepo voltage.lock is up to date (version ${monorepoLock.version})`);
+      return;
+    }
+
+    console.log(`✅ Found ${monorepoLock.packages.length} package(s) with voltage.lock files:`);
+    for (const pkg of monorepoLock.packages) {
+      console.log(`   - ${pkg.packageName}@${pkg.packageVersion} (${pkg.file})`);
+    }
+
+    writeMonorepoLockFile(monorepoLock, outputPath);
+
+    const action = existingMonorepoLock ? 'Updated' : 'Generated';
+    console.log(`✅ ${action} monorepo voltage.lock (version ${monorepoLock.version})`);
+
+  } catch (error) {
+    console.error(`❌ Error: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    process.exit(1);
+  }
+}
+
+/**
+ * Register the concat-lock command with the CLI
+ */
+export function registerConcatLockCommand(cli: CLI) {
+  cli
+    .command('concat-lock', 'Concatenate multiple voltage.lock files from packages in a monorepo')
+    .action(() => {
+      concatLockCommand();
+    });
+}

--- a/packages/voltage-schema/src/cli/commands/generate.ts
+++ b/packages/voltage-schema/src/cli/commands/generate.ts
@@ -5,6 +5,7 @@ import { type AnalyticsGlobals, type AnalyticsEvents, type GenerationConfig, typ
 import { validateAnalyticsFiles } from "../validation";
 import { getAnalyticsConfig } from "../utils/analyticsConfigHelper";
 import { parseSchemaFile } from "../validation/fileValidation";
+import { generateLockFile, writeLockFile } from "../utils/lockFileGenerator";
 
 interface TrackingConfigProperty {
   name: string;
@@ -367,6 +368,12 @@ export function registerGenerateCommand(cli: CLI) {
 
         const config = getAnalyticsConfig();
         const generationConfigs = config.generates;
+
+        // Generate voltage.lock file first - this validates all schema files
+        console.log("🔐 Generating voltage.lock file...");
+        const lockFile = generateLockFile(generationConfigs);
+        writeLockFile(lockFile);
+        console.log("✅ Generated voltage.lock");
 
         generationConfigs.forEach((generationConfig: GenerationConfig) => {
           const { events, groups, dimensions, meta, output, disableComments, eventKeyPropertyName } = generationConfig;

--- a/packages/voltage-schema/src/cli/index.ts
+++ b/packages/voltage-schema/src/cli/index.ts
@@ -5,6 +5,7 @@ import { registerDimensionsCommand } from "./commands/dimensions";
 import { registerPropertiesCommand } from "./commands/properties";
 import { registerEventsCommand } from "./commands/events";
 import { registerGenerateCommand } from "./commands/generate";
+import { registerConcatLockCommand } from "./commands/concat-lock";
 
 const cli = new CLI();
 
@@ -15,6 +16,7 @@ registerDimensionsCommand(cli);
 registerPropertiesCommand(cli);
 registerEventsCommand(cli);
 registerGenerateCommand(cli);
+registerConcatLockCommand(cli);
 
 // Parse command line arguments
 cli.parse(process.argv);

--- a/packages/voltage-schema/src/cli/utils/lockFileGenerator.ts
+++ b/packages/voltage-schema/src/cli/utils/lockFileGenerator.ts
@@ -1,0 +1,251 @@
+import fs from "fs";
+import path from "path";
+import crypto from "crypto";
+import { parseSchemaFile } from "../validation/fileValidation";
+import { GenerationConfig } from "../../types";
+
+// Lock file data structure types
+export interface VoltageSchemaSource {
+  file: string;
+  data: any;
+  hash: string;
+}
+
+export interface VoltageGenerationEntry {
+  output: string;
+  config: Omit<GenerationConfig, 'output'>;
+  sources: {
+    events: VoltageSchemaSource;
+    groups?: VoltageSchemaSource[];
+    dimensions?: VoltageSchemaSource[];
+    meta?: VoltageSchemaSource;
+  };
+  hash: string;
+  version: string | number; // Support both for backward compatibility
+}
+
+export interface VoltageLockFile {
+  voltageSchemaVersion: string;
+  version: string | number; // Support both for backward compatibility
+  hash: string;
+  configFile: string;
+  generates: VoltageGenerationEntry[];
+}
+
+/**
+ * Parses a version (string or number) into major and minor components
+ * Handles migration from old integer versions to new semver format
+ */
+export function parseVersion(version: string | number): { major: number; minor: number } {
+  if (typeof version === 'number') {
+    // Legacy integer version - convert to major.0
+    return {
+      major: version,
+      minor: 0
+    };
+  }
+
+  const parts = version.split('.');
+  return {
+    major: parseInt(parts[0] || '1', 10),
+    minor: parseInt(parts[1] || '0', 10)
+  };
+}
+
+/**
+ * Creates a version string from major and minor numbers
+ */
+export function createVersion(major: number, minor: number): string {
+  return `${major}.${minor}`;
+}
+
+// Note: Breaking change detection can be added later if needed
+// For now, we'll keep it simple and treat all changes as minor version bumps
+
+/**
+ * Creates a deterministic hash for any object
+ */
+export function createContentHash(content: any): string {
+  // Create a deep deterministic JSON string with sorted keys at all levels
+  const normalizedContent = JSON.stringify(content, (key, value) => {
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      // Sort object keys for deterministic output
+      const sorted: any = {};
+      Object.keys(value).sort().forEach(k => {
+        sorted[k] = value[k];
+      });
+      return sorted;
+    }
+    return value;
+  });
+  return crypto.createHash('sha256').update(normalizedContent).digest('hex').substring(0, 16);
+}
+
+/**
+ * Reads and processes a schema file, returning source data with hash
+ */
+export function readSchemaSource(filePath: string): VoltageSchemaSource {
+  const absolutePath = path.resolve(process.cwd(), filePath);
+
+  if (!fs.existsSync(absolutePath)) {
+    throw new Error(`Schema file not found: ${filePath}`);
+  }
+
+  const result = parseSchemaFile(absolutePath);
+  if (!result.isValid || !result.data) {
+    const errorMessage = result.errors ? result.errors.join(', ') : 'Unknown parsing error';
+    throw new Error(`Failed to parse schema file ${filePath}: ${errorMessage}`);
+  }
+
+  return {
+    file: filePath, // Store relative path
+    data: result.data,
+    hash: createContentHash(result.data)
+  };
+}
+
+/**
+ * Gets the voltage-schema package version
+ */
+export function getVoltageSchemaVersion(): string {
+  try {
+    const packageJsonPath = path.resolve(__dirname, '../../../package.json');
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+    return packageJson.version;
+  } catch (error) {
+    // Fallback if we can't read the package.json
+    return '0.0.0';
+  }
+}
+
+/**
+ * Reads the existing lock file if it exists
+ */
+export function readExistingLockFile(): VoltageLockFile | null {
+  const lockFilePath = path.resolve(process.cwd(), 'voltage.lock');
+
+  if (!fs.existsSync(lockFilePath)) {
+    return null;
+  }
+
+  try {
+    const content = fs.readFileSync(lockFilePath, 'utf8');
+    return JSON.parse(content);
+  } catch (error) {
+    // If we can't parse the existing lock file, treat it as if it doesn't exist
+    return null;
+  }
+}
+
+/**
+ * Processes a generation config and returns the generation entry
+ */
+export function processGenerationConfig(
+  genConfig: GenerationConfig,
+  existingEntry?: VoltageGenerationEntry
+): VoltageGenerationEntry {
+  const sources: VoltageGenerationEntry['sources'] = {
+    events: readSchemaSource(genConfig.events)
+  };
+
+  // Process groups if present
+  if (genConfig.groups && genConfig.groups.length > 0) {
+    sources.groups = genConfig.groups.map(groupFile => readSchemaSource(groupFile));
+  }
+
+  // Process dimensions if present
+  if (genConfig.dimensions && genConfig.dimensions.length > 0) {
+    sources.dimensions = genConfig.dimensions.map(dimensionFile => readSchemaSource(dimensionFile));
+  }
+
+  // Process meta if present
+  if (genConfig.meta) {
+    sources.meta = readSchemaSource(genConfig.meta);
+  }
+
+  // Create config without output for hashing
+  const { output, ...configWithoutOutput } = genConfig;
+
+  // Create hash for this generation entry
+  const entryContent = {
+    config: configWithoutOutput,
+    sources
+  };
+  const entryHash = createContentHash(entryContent);
+
+  // Determine version using semantic versioning
+  let version = '1.0';
+  if (existingEntry) {
+    if (existingEntry.hash === entryHash) {
+      // No changes, keep existing version (convert to string format if needed)
+      const { major, minor } = parseVersion(existingEntry.version);
+      version = createVersion(major, minor);
+    } else {
+      // Changes detected, increment minor version
+      const { major, minor } = parseVersion(existingEntry.version);
+      version = createVersion(major, minor + 1);
+    }
+  }
+
+  return {
+    output: genConfig.output,
+    config: configWithoutOutput,
+    sources,
+    hash: entryHash,
+    version
+  };
+}
+
+/**
+ * Generates the complete voltage.lock file
+ */
+export function generateLockFile(generationConfigs: GenerationConfig[]): VoltageLockFile {
+  const existingLockFile = readExistingLockFile();
+  const voltageSchemaVersion = getVoltageSchemaVersion();
+
+  // Process each generation config
+  const generates = generationConfigs.map(genConfig => {
+    // Find existing entry by output path for version comparison
+    const existingEntry = existingLockFile?.generates.find(entry => entry.output === genConfig.output);
+    return processGenerationConfig(genConfig, existingEntry);
+  });
+
+  // Create overall lock file content
+  const lockFileContent = {
+    voltageSchemaVersion,
+    configFile: 'voltage.config.js',
+    generates
+  };
+
+  // Create hash for overall lock file
+  const lockFileHash = createContentHash(lockFileContent);
+
+  // Determine overall version based on highest generation entry version change
+  let version = '1.0';
+  if (existingLockFile) {
+    if (existingLockFile.hash === lockFileHash) {
+      // No changes, keep existing version (convert to string format if needed)
+      const { major, minor } = parseVersion(existingLockFile.version);
+      version = createVersion(major, minor);
+    } else {
+      // Changes detected, increment minor version
+      const { major: currentMajor, minor: currentMinor } = parseVersion(existingLockFile.version);
+      version = createVersion(currentMajor, currentMinor + 1);
+    }
+  }
+
+  return {
+    ...lockFileContent,
+    version,
+    hash: lockFileHash
+  };
+}
+
+/**
+ * Writes the lock file to disk (minified)
+ */
+export function writeLockFile(lockFile: VoltageLockFile): void {
+  const lockFilePath = path.resolve(process.cwd(), 'voltage.lock');
+  const content = JSON.stringify(lockFile, null, 0); // Minified JSON
+  fs.writeFileSync(lockFilePath, content, 'utf8');
+}


### PR DESCRIPTION
- Deterministically generate a voltage.lock file when running the generate command
- Add a "concat-lock" command for monorepos to concat their lockfiles together in a single root voltage.lock file